### PR TITLE
Fixed meta summary for twitter and facebook description

### DIFF
--- a/templates/article.html
+++ b/templates/article.html
@@ -4,11 +4,11 @@
 <meta name="twitter:creator" content="{{ TWITTER_USERNAME }}">
 <meta name="twitter:url" content="{{ SITEURL }}/{{ article.url }}">
 <meta name="twitter:title" content="{{ SITENAME }} ~ {{ article.title }}">
-<meta name="twitter:description" content="{{ article.summary }}">
+<meta name="twitter:description" content="{{ article.summary|striptags|escape }}">
 
 <!-- Facebook Meta Data -->
 <meta property="og:title" content="{{ SITENAME }} ~ {{ article.title }}" />
-<meta property="og:description" content="{{ article.summary }}" />
+<meta property="og:description" content="{{ article.summary|striptags|escape  }}" />
 <meta property="og:image" content="" />
 {% endblock head %}
 {% block title %}{{ article.title }}{% endblock %}


### PR DESCRIPTION
Currently, the content for twitter/facebook description is HTML.  This causes the page to render incorrectly on mobile devices.

![image](https://cloud.githubusercontent.com/assets/7358102/13431142/fdd450ce-dfbf-11e5-8b04-622095d192e3.png)
