### PR TITLE
Add blogrolls support

### DIFF
--- a/static/css/style.css
+++ b/static/css/style.css
@@ -201,6 +201,14 @@ aside > h2 {
 }
 
 
+.blog_roll_link 
+{
+  display: block;
+  padding: 0.33147rem 0;
+  border-bottom: 3px solid #328cc7;
+} 
+
+
 /*--------Responsive------------*/
 
 @media (max-width: 800px) {

--- a/templates/base.html
+++ b/templates/base.html
@@ -75,13 +75,6 @@
         {% if DISPLAY_PAGES_ON_MENU and PAGES %}{% for p in pages %}
           <li><a class="nav__link" href="{{ SITEURL }}/{{ p.url }}">{{ p.title }}</a></li>
         {% endfor %}{% endif %}
-
-        {% if LINKS %}
-          <li><h1 class="blog_roll_link"><br/><br/><br/>BLOGROLLS</h1></li>
-          {% for name, link in LINKS %}
-            <li><a class="blog_roll_link" href="{{ link }}">{{ name }}</a></li>
-          {% endfor %}
-        {% endif %}
         
       </ul>
     </nav>
@@ -110,6 +103,16 @@
       {% endfor %}
     </ul> 
     {% endif %}
+
+    {% if LINKS %}
+      <h2 class="blog_roll_link"><br/>BLOGROLLS</h2>
+      <ul class="navbar">
+      {% for name, link in LINKS %}
+        <li><a href="{{ link }}">{{ name }}</a></li>
+      {% endfor %}
+      </ul> 
+    {% endif %}
+
   </aside>
 
   <!-- Content -->

--- a/templates/base.html
+++ b/templates/base.html
@@ -75,6 +75,13 @@
         {% if DISPLAY_PAGES_ON_MENU and PAGES %}{% for p in pages %}
           <li><a class="nav__link" href="{{ SITEURL }}/{{ p.url }}">{{ p.title }}</a></li>
         {% endfor %}{% endif %}
+
+        {% if LINKS %}
+          <li><h1 class="blog_roll_link"><br/><br/><br/>BLOGROLLS</h1></li>
+          {% for name, link in LINKS %}
+            <li><a class="blog_roll_link" href="{{ link }}">{{ name }}</a></li>
+          {% endfor %}
+        {% endif %}
         
       </ul>
     </nav>


### PR DESCRIPTION
Add blogrolls support in `style.css` and `base.html`

To use it, set variable `LINKS` in `pelicanconf.py` like:
```python
# Blogroll
LINKS = (
	('google', 'https://www.google.com/'),
	)
```
then it would work link [EtaoinWu's Blog](https://etaoinwu.github.io).
