### PR TITLE
Fix 'pages' variable check

### DIFF
--- a/templates/base.html
+++ b/templates/base.html
@@ -79,7 +79,7 @@
                 <li><a class="nav__link" href="{{ link }}">{{ title }}</a></li>
             {% endfor %}
 
-            {% if DISPLAY_PAGES_ON_MENU and PAGES %}{% for p in pages %}
+            {% if DISPLAY_PAGES_ON_MENU and pages %}{% for p in pages %}
                 <li><a class="nav__link" href="{{ SITEURL }}/{{ p.url }}">{{ p.title }}</a></li>
             {% endfor %}{% endif %}
 


### PR DESCRIPTION
Fixes the uppercase 'PAGES' variable.
Pelican made a breaking change and now requires lowercase:
http://docs.getpelican.com/en/stable/faq.html#since-i-upgraded-pelican-my-pages-are-no-longer-rendered