### PR TITLE
Set back the default padding-left or ol in article

### DIFF
--- a/static/css/style.css
+++ b/static/css/style.css
@@ -66,7 +66,7 @@ body > article, footer {
   padding: 20px 80px 10px;
 }
 
-article ol
+article ol.posts
 {
   padding-left: 0;
 }

--- a/templates/index.html
+++ b/templates/index.html
@@ -15,7 +15,7 @@
 {% block content %}
     <h1 class="title">Hi, I'm {{ AUTHOR }}</h1>
     {% if articles %}
-        <ol>
+        <ol class="posts">
             {% block heading %}<h2 class="latest">Latest Posts</h2>{% endblock %}
             {% for article in (articles_page.object_list if articles_page else articles) %}
                 <li class="post_list"><p class="post_entry">


### PR DESCRIPTION
It seems `article ol`'s `padding-left` is set to `0`, for the post list of the index page. However, it affects the ordered list in the individual list as well.

I am not 100% sure if it's a bug. Because it was intended that `padding-left: 0` on the individual article's ordered. But still it didn't look very nice to me.